### PR TITLE
Adding auto deployment to github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+language: node_js
+node_js:
+  - "node"
+  - "6"
+install:
+  - npm install
+script: npm run build
+after_success:
+  - npm run-script doc
+  - echo 'node_modules' > .gitignore
+  - cp node_modules/openlayers/dist/ol-debug.js dist/ol-debug.js
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: master
+node: 'node'

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <title>OpenLayers Editor</title>
   </head>
   <body>
-    <script src="node_modules/openlayers/dist/ol-debug.js"></script>
+    <script src="dist/ol-debug.js"></script>
     <script src="dist/ole.js"></script>
 
     <div id="map" style="position:absolute;top:0;bottom:0;left:0;right:0;"></div>


### PR DESCRIPTION
Deployment happens only on master branch updates.
This feature requires, that the env variable GITHUB_TOKEN is set
and present in the travis-ci build configuration.
This should be a github private access token with public_repo scope.
Deployment happens with git push --force as descripted in
https://docs.travis-ci.com/user/deployment/pages/