### PR TITLE
Export OLE to window.ole using Webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "Editor"
   ],
   "license": "BSD-2-Clause",
+  "main" : "dist/ole.js",
   "repository": "github:geops/ole2",
   "devDependencies": {
     "babel": "^6.23.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-window.ole = {};
-
 import Editor from './editor.js';
 import Control from './control/control.js';
 import CadControl from './control/cad.js';
@@ -9,7 +7,7 @@ import MoveControl from './control/move.js';
 import ModifyControl from './control/modify.js';
 import DeleteControl from './control/delete.js';
 
-window.ole = {
+const ole = {
   Editor: Editor,
   Control: Control,
   CadControl: CadControl,
@@ -19,3 +17,5 @@ window.ole = {
   ModifyControl: ModifyControl,
   DeleteControl: DeleteControl
 };
+
+module.exports = ole;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,8 @@ module.exports = {
 
   output: {
     filename: 'ole.js',
+    library: 'ole',
+    libraryTarget: 'window',
     publicPath: '/dist/',
     path: path.resolve(__dirname, 'dist')
   },


### PR DESCRIPTION
Avoids writing to global window object in OLE module. This allows other modules to import OLE into custom namespace.