### PR TITLE
Move JSTS to peer dependency.

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -7,11 +7,25 @@ const styleLoader = require('@neutrinojs/style-loader');
 const devServer = require('@neutrinojs/dev-server');
 
 module.exports = neutrino => {
-  neutrino.use(airbnb, { eslint: { globals: ['ol'] } });
-  neutrino.use(library, { name: 'ole' });
+  neutrino.use(airbnb, { eslint: { globals: ['jsts', 'ol'] } });
+  neutrino.use(library, {
+    name: 'ole',
+    babel: {
+      presets: [
+        ['babel-preset-env', {
+          targets: {
+            browsers: ["last 2 versions", "ie >= 10"]
+          }
+        }]
+      ]
+    }
+  });
   neutrino.use(imageLoader);
   neutrino.use(styleLoader, { extract: false });
   neutrino.use(devServer);
+
+  // neutrino.config.plugins.delete('babel-minify').end();
+  // neutrino.config.externals(['jsts']);
 
   neutrino.on('test', () => new Promise((resolve, reject) =>
     start(neutrino.config.toConfig(), neutrino).fork(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 0.0.2 - 2018-04-17
+### Added
+- Support for Internet Explorer >= 10 has been added.
+
+### Changed
+- Moved JSTS to peer depency to fix broken builds and reduce build size.
+
 ## 0.0.1 - 2018-03-20
 ### Added
 - Using [JSTS](https://github.com/bjornharrtell/jsts) for topology operations.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <script src="https://unpkg.com/openlayers@^4/dist/ol.js"></script>
+    <script src="https://unpkg.com/jsts@^1/dist/jsts.js"></script>
     <script src="build/index.js"></script>
     <div id="app">
       <div id="header">

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
     "neutrino": "^8.1.2",
     "openlayers": "^4.6.5"
   },
-  "dependencies": {
-    "jsts": "^1.6.0"
-  },
   "peerDependencies": {
+    "jsts": "^1.6.0",
     "ol": "^4.6.4"
   }
 }

--- a/src/control/buffer.js
+++ b/src/control/buffer.js
@@ -1,5 +1,5 @@
-import OL3Parser from '../../node_modules/jsts/org/locationtech/jts/io/OL3Parser';
-import { BufferOp } from '../../node_modules/jsts/org/locationtech/jts/operation/buffer';
+// import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+// import { BufferOp } from 'jsts/org/locationtech/jts/operation/buffer';
 import Control from './control';
 import bufferSVG from '../../img/buffer.svg';
 
@@ -45,11 +45,11 @@ class BufferControl extends Control {
    * @param {Number} width Buffer width in map units.
    */
   buffer(width) {
-    const parser = new OL3Parser();
+    const parser = new jsts.io.OL3Parser();
     const features = this.selectInteraction.getFeatures().getArray();
     for (let i = 0; i < features.length; i += 1) {
       const jstsGeom = parser.read(features[i].getGeometry());
-      const bo = new BufferOp(jstsGeom);
+      const bo = new jsts.operation.buffer.BufferOp(jstsGeom);
       const buffered = bo.getResultGeometry(width);
       features[i].setGeometry(parser.write(buffered));
     }

--- a/src/control/difference.js
+++ b/src/control/difference.js
@@ -1,5 +1,5 @@
-import OL3Parser from '../../node_modules/jsts/org/locationtech/jts/io/OL3Parser';
-import OverlayOp from '../../node_modules/jsts/org/locationtech/jts/operation/overlay/OverlayOp';
+// import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+// import OverlayOp from 'jsts/org/locationtech/jts/operation/overlay/OverlayOp';
 import TopologyControl from './topology';
 import diffSVG from '../../img/difference.svg';
 
@@ -34,12 +34,12 @@ class Difference extends TopologyControl {
       return;
     }
 
-    const parser = new OL3Parser();
+    const parser = new jsts.io.OL3Parser();
 
     for (let i = 1; i < features.length; i += 1) {
       const geom = parser.read(features[0].getGeometry());
       const otherGeom = parser.read(features[i].getGeometry());
-      const diffGeom = OverlayOp.difference(geom, otherGeom);
+      const diffGeom = jsts.operation.overlay.OverlayOp.difference(geom, otherGeom);
       features[0].setGeometry(parser.write(diffGeom));
       features[i].setGeometry(null);
     }

--- a/src/control/intersection.js
+++ b/src/control/intersection.js
@@ -1,5 +1,5 @@
-import OL3Parser from '../../node_modules/jsts/org/locationtech/jts/io/OL3Parser';
-import OverlayOp from '../../node_modules/jsts/org/locationtech/jts/operation/overlay/OverlayOp';
+// import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+// import OverlayOp from 'jsts/org/locationtech/jts/operation/overlay/OverlayOp';
 import TopologyControl from './topology';
 import intersectionSVG from '../../img/intersection.svg';
 
@@ -34,12 +34,12 @@ class Intersection extends TopologyControl {
       return;
     }
 
-    const parser = new OL3Parser();
+    const parser = new jsts.io.OL3Parser();
 
     for (let i = 1; i < features.length; i += 1) {
       const geom = parser.read(features[0].getGeometry());
       const otherGeom = parser.read(features[i].getGeometry());
-      const intersectGeom = OverlayOp.intersection(geom, otherGeom);
+      const intersectGeom = jsts.operation.overlay.OverlayOp.intersection(geom, otherGeom);
       features[0].setGeometry(parser.write(intersectGeom));
       features[i].setGeometry(null);
     }

--- a/src/control/union.js
+++ b/src/control/union.js
@@ -1,5 +1,5 @@
-import OL3Parser from '../../node_modules/jsts/org/locationtech/jts/io/OL3Parser';
-import UnionOp from '../../node_modules/jsts/org/locationtech/jts/operation/union/UnionOp';
+// import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+// import UnionOp from 'jsts/org/locationtech/jts/operation/union/UnionOp';
 import TopologyControl from './topology';
 import unionSVG from '../../img/union.svg';
 
@@ -29,12 +29,12 @@ class Union extends TopologyControl {
    */
   applyTopologyOperation(features) {
     super.applyTopologyOperation(features);
-    const parser = new OL3Parser();
+    const parser = new jsts.io.OL3Parser();
 
     for (let i = 1; i < features.length; i += 1) {
       const geom = parser.read(features[0].getGeometry());
       const otherGeom = parser.read(features[i].getGeometry());
-      const unionGeom = UnionOp.union(geom, otherGeom);
+      const unionGeom = jsts.operation.overlay.OverlayOp.union(geom, otherGeom);
       features[0].setGeometry(parser.write(unionGeom));
       features[i].setGeometry(null);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <script src="https://unpkg.com/openlayers@^4/dist/ol.js"></script>
+    <script src="https://unpkg.com/jsts@^1/dist/jsts.js"></script>
     <script src="index.js"></script>
     <div id="map"></div>
     <script type="text/javascript">


### PR DESCRIPTION
This will fix broken builds in Firefox, because Neutrino does not compile
external NPM packages correctly. In addition the bundle size is reduced
significantly and support for IE >= 10 has been added. Usage of topology
controls will require JSTS to be available globally (see index.html).

Fixes #60 and #62.